### PR TITLE
fix remote connection url

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -268,7 +268,8 @@ export default class Ad4mConnect extends LitElement {
     ele.style.display = 'block';
 
     const qrCodeSuccessCallback = (decodedText, decodedResult) => {
-      this._client.connectRemote(`${decodedText.replace('http', 'ws')}/graphql`);
+      console.log("Trying to connect with text: ", decodedText);
+      this._client.connectRemote(decodedText);
       html5QrCode.stop();
       ele.style.display = 'none';
     };


### PR DESCRIPTION
with PR on ad4min: https://github.com/perspect3vism/ad4min/pull/41 we fixed the proxy url so it contains wss & /graphql in the url, thus we should just be able to scan the qr directly now 